### PR TITLE
Initial code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,51 +1,12 @@
 # Contributor Code of Conduct
+## Version 0.1
 
-As contributors and maintainers of this project, and in the interest of
-fostering an open and welcoming community, we pledge to respect all people who
-contribute through reporting issues, posting feature requests, updating
-documentation, submitting pull requests or patches, and other activities.
+As contributors and maintainers of the CakePHP project, we pledge to respect everyone who contributes by posting issues, updating documentation, submitting pull requests, providing feedback in comments, and any other activities.
 
-We are committed to making participation in this project a harassment-free
-experience for everyone, regardless of level of experience, gender, gender
-identity and expression, sexual orientation, disability, personal appearance,
-body size, race, ethnicity, age, religion, or nationality.
+Communication through any of CakePHP's channels (GitHub, IRC, mailing lists, Google+, Twitter, etc.) must be constructive and never resort to personal attacks, trolling, public or private harrassment, insults, or other unprofessional conduct.
 
-Examples of unacceptable behavior by participants include:
+We promise to extend courtesy and respect to everyone involved in this project regardless of gender, gender identity, sexual orientation, disability, age, race, ethnicity, religion, or level of experience. We expect anyone contributing to the CakePHP project to do the same.
 
-* The use of sexualized language or imagery
-* Personal attacks
-* Trolling or insulting/derogatory comments
-* Public or private harassment
-* Publishing other's private information, such as physical or electronic
-  addresses, without explicit permission
-* Other unethical or unprofessional conduct
+If any member of the community violates this code of conduct, the maintainers of the CakePHP project may take action, removing issues, comments, and PRs or blocking accounts as deemed appropriate.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
-
-By adopting this Code of Conduct, project maintainers commit themselves to
-fairly and consistently applying these principles to every aspect of managing
-this project. Project maintainers who do not follow or enforce the Code of
-Conduct may be permanently removed from the project team.
-
-This code of conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community.
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting a project maintainer at conduct@cakefoundation.org. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. Maintainers are
-obligated to maintain confidentiality with regard to the reporter of an
-incident.
-
-
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 1.3.0, available at
-[http://contributor-covenant.org/version/1/3/0/][version]
-
-
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/3/0/
+If you are subject to or witness unacceptable behavior, or have any other concerns, please email us at [conduct@cakefoundation.org](mailto:conduct@cakefoundation.org).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,51 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of
+fostering an open and welcoming community, we pledge to respect all people who
+contribute through reporting issues, posting feature requests, updating
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
+body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic
+  addresses, without explicit permission
+* Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to
+fairly and consistently applying these principles to every aspect of managing
+this project. Project maintainers who do not follow or enforce the Code of
+Conduct may be permanently removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting a project maintainer at conduct@cakefoundation.org. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. Maintainers are
+obligated to maintain confidentiality with regard to the reporter of an
+incident.
+
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.3.0, available at
+[http://contributor-covenant.org/version/1/3/0/][version]
+
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/3/0/

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 CakePHP
+Copyright (c) 2015 Coraline Ada Ehmke
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +20,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# CoC
-Contributor Code of Conduct
+# CakePHP Contributor Code of Conduct
+
+See [CODE_OF_CONDUCT.md](https://github.com/cakephp/code-of-conduct/blob/master/CODE_OF_CONDUCT.md).
+
+This code of conduct applies to all of the projects under the [CakePHP organization on GitHub](https://github.com/cakephp/) and the CakePHP community at large (IRC, mailing lists, Google+, Twitter, etc.).
+
+See the [contributing guidelines](https://github.com/cakephp/cakephp/blob/master/CONTRIBUTING.md) and the [CakePHP Cookbook](http://book.cakephp.org/3.0/en/contributing.html) for technical details of contributing to CakePHP or its related projects.
+
+
+## Events
+
+If you are running a CakePHP meetup, conference, user group, or other type of event, we encourage you to adopt and provide an appropriate code of conduct.
+The [confcodeofconduct.com](http://confcodeofconduct.com/) template is a good starting point.
+You should also provide contact information for atttendees to get help or report a violation.
+
+For more on adopting a code of conduct, see [Ashe Dryden's FAQ](http://ashedryden.com/blog/codes-of-conduct-101-faq).
+
+
+## Credits
+
+Based on the [Contributor Covenant](https://github.com/CoralineAda/contributor_covenant) by [Coraline Ada Ehmke](https://github.com/CoralineAda/contributor_covenant).
+
+If you have suggestions to improve this code of conduct, please submit an issue or PR.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ For more on adopting a code of conduct, see [Ashe Dryden's FAQ](http://ashedryde
 
 ## Credits
 
-Based on the [Contributor Covenant](https://github.com/CoralineAda/contributor_covenant) by [Coraline Ada Ehmke](https://github.com/CoralineAda/contributor_covenant).
+Based on the [Contributor Covenant](https://github.com/CoralineAda/contributor_covenant) by [Coraline Ada Ehmke](https://github.com/CoralineAda).
 
 If you have suggestions to improve this code of conduct, please submit an issue or PR.


### PR DESCRIPTION
Continues the work started in cakephp/cakephp#7725.

A couple things:
- [ ] Needs proofreading. I started from the Angular repo and made what seemed appropriate adjustments.
- [x] Check ALL links. I think they should all be good, but more eyes is also good.
- LICENSE.txt copyright. Angular's LICENSE file (properly) grants copyright on the Contributor Covenant content to @coralineAda: We should do that as well. I wanted to point this out as a change from the "stock" LICENSE that gets committed with new projects.
